### PR TITLE
Improve C99 compatibility

### DIFF
--- a/mod_flvx.c
+++ b/mod_flvx.c
@@ -48,6 +48,7 @@
 #include "http_config.h"
 #include "http_protocol.h"
 #include "http_log.h"
+#include "http_request.h"
 #include "apr_buckets.h"
 #include "apr_strings.h"
 


### PR DESCRIPTION
Include "http_request.h" for the ap_update_mtime function.  Avoids an implicit function declaration, thus improving compatibility with future compilers which do not accept this obsolete construct by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
